### PR TITLE
new confluence_add_pagename_prefix config

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -89,6 +89,8 @@ def setup(app):
     app.add_config_value('confluence_prev_next_buttons_location', None, False)
     """Suffix to put after section numbers, before section name"""
     app.add_config_value('confluence_secnumber_suffix', None, False)
+    """Add pagename as prefix on anchors to fix links on confluence"""
+    app.add_config_value('confluence_add_pagename_prefix', None, False)
 
     """(configuration - publishing)"""
     """Request for publish password to come from interactive session."""

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -96,6 +96,11 @@ def validate_configuration(builder):
 
     # ##################################################################
 
+    validator.conf('confluence_add_pagename_prefix') \
+             .bool()
+
+    # ##################################################################
+
     if config.confluence_client_cert is not None:
         client_cert = config.confluence_client_cert
         if isinstance(client_cert, tuple):

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -66,6 +66,7 @@ def apply_defaults(conf):
         'confluence_purge_from_master',
         'confluence_remove_title',
         'confluence_watch',
+        'confluence_add_pagename_prefix',
     ]
     for key in config2bool:
         if getattr(conf, key) is not None:

--- a/tests/unit-tests/test_rst_references.py
+++ b/tests/unit-tests/test_rst_references.py
@@ -190,3 +190,174 @@ class TestConfluenceRstReferences(unittest.TestCase):
             link_body = ac_link.find('ac:link-body')
             self.assertIsNotNone(link_body)
             self.assertEqual(link_body.text, 'references section')
+
+    def test_storage_rst_references_add_pagename_prefix(self):
+        self.config['confluence_add_pagename_prefix'] = True
+        out_dir = build_sphinx(self.dataset, config=self.config,
+            filenames=self.filenames)
+
+        with parse('references', out_dir) as data:
+            a_tags = data.find_all('a')
+            self.assertEqual(len(a_tags), 6)
+
+            # basic links ##############################################
+
+            # (link 1)
+            a_tag = a_tags.pop(0)
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], 'https://www.example.com/')
+            self.assertEqual(a_tag.text, 'https://www.example.com/')
+
+            # (link 2)
+            a_tag = a_tags.pop(0)
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], 'mailto:someone@example.com')
+            self.assertEqual(a_tag.text, 'someone@example.com')
+
+            # (link 3)
+            self.assertTrue(a_tag.has_attr('href'))
+            a_tag = a_tags.pop(0)
+            self.assertEqual(a_tag['href'], 'https://example.com/')
+            self.assertEqual(a_tag.text, 'custom name')
+
+            # (link 4)
+            a_tag = a_tags.pop(0)
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], 'https://example.com/')
+            self.assertEqual(a_tag.text, 'a link')
+
+            # (link 5)
+            a_tag = a_tags.pop(0)
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], 'https://example.org/')
+            self.assertEqual(a_tag.renderContents().decode(), '&gt;')
+
+            # (link 6)
+            a_tag = a_tags.pop(0)
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], 'https://example.com/')
+
+            stronged = a_tag.find('strong')
+            self.assertIsNotNone(stronged)
+            self.assertEqual(stronged.text, 'a bolded link')
+
+            # anchors ##################################################
+
+            anchors = data.find_all('ac:structured-macro',
+                {'ac:name': 'anchor'})
+            self.assertEqual(len(anchors), 1)
+
+            # (anchor 1)
+            anchor = anchors.pop(0)
+
+            anchor_id = anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_id)
+            self.assertEqual(anchor_id.text, 'my-reference-label1')
+
+            # document links ###########################################
+
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 4)
+
+            # (ac-link 1) external document
+            ac_link = ac_links.pop(0)
+
+            page_ref = ac_link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'references-ref')
+
+            link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(link_body)
+            self.assertEqual(link_body.text, 'references-ref')
+
+            # (ac-link 2) external document with custom label
+            ac_link = ac_links.pop(0)
+
+            page_ref = ac_link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'references-ref')
+
+            link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(link_body)
+            self.assertEqual(link_body.text, 'custom name')
+
+            # (ac-link 3) link directly to section target
+            ac_link = ac_links.pop(0)
+
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'references-sub-section')
+
+            link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(link_body)
+            self.assertEqual(link_body.text, 'sub-section')
+
+            # (ac-link 4) link to anchor
+            ac_link = ac_links.pop(0)
+
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'references-my-reference-label1')
+
+            link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(link_body)
+            self.assertEqual(link_body.text, 'internal anchor')
+
+        with parse('references-ref', out_dir) as data:
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 4)
+
+            # (ac-link 1) external document
+            ac_link = ac_links.pop(0)
+
+            page_ref = ac_link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'references')
+
+            link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(link_body)
+            self.assertEqual(link_body.text, 'references')
+
+            # (ac-link 2) external document with custom label
+            ac_link = ac_links.pop(0)
+
+            page_ref = ac_link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'references')
+
+            link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(link_body)
+            self.assertEqual(link_body.text, 'custom name')
+
+            # (ac-link 3) link directly to section target
+            ac_link = ac_links.pop(0)
+
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'my-reference-label1')
+
+            page_ref = ac_link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'references')
+
+            link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(link_body)
+            self.assertEqual(link_body.text, 'references anchor')
+
+            # (ac-link 4) link to anchor
+            ac_link = ac_links.pop(0)
+
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'sub-section')
+
+            page_ref = ac_link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'references')
+
+            link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(link_body)
+            self.assertEqual(link_body.text, 'references section')
+        self.config['confluence_add_pagename_prefix'] = False


### PR DESCRIPTION
Add pagename as prefix on internal anchors, to fix: https://github.com/sphinx-contrib/confluencebuilder/issues/443